### PR TITLE
Initial label library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint

--- a/XCUITestExtensions.xcodeproj/project.pbxproj
+++ b/XCUITestExtensions.xcodeproj/project.pbxproj
@@ -1,0 +1,447 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		897934CC1E4CD03300546131 /* XCUITestExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 897934CA1E4CD03300546131 /* XCUITestExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		897934D41E4CD0A400546131 /* MCLabel.h in Headers */ = {isa = PBXBuildFile; fileRef = 897934D21E4CD0A400546131 /* MCLabel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		897934DF1E4CD1DA00546131 /* XCUITestExtensions.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 897934C71E4CD03300546131 /* XCUITestExtensions.framework */; };
+		897934E91E4CD35900546131 /* MCLabelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 897934DC1E4CD1DA00546131 /* MCLabelTests.m */; };
+		897934ED1E4CD51E00546131 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 897934E61E4CD2A800546131 /* XCTest.framework */; };
+		897934F01E4CDC8800546131 /* MCLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = 897934EF1E4CDC8800546131 /* MCLabel.m */; };
+		89CC4A3C1E4CEEFE00323361 /* MCLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89CC4A3B1E4CEEFE00323361 /* MCLabelTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		897934E01E4CD1DA00546131 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 897934BE1E4CD03300546131 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 897934C61E4CD03300546131;
+			remoteInfo = XCUITestExtensions;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		897934C71E4CD03300546131 /* XCUITestExtensions.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = XCUITestExtensions.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		897934CA1E4CD03300546131 /* XCUITestExtensions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XCUITestExtensions.h; sourceTree = "<group>"; };
+		897934CB1E4CD03300546131 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		897934D21E4CD0A400546131 /* MCLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MCLabel.h; sourceTree = "<group>"; };
+		897934DA1E4CD1DA00546131 /* XCUITestExtensionsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = XCUITestExtensionsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		897934DC1E4CD1DA00546131 /* MCLabelTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MCLabelTests.m; sourceTree = "<group>"; };
+		897934DE1E4CD1DA00546131 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		897934E61E4CD2A800546131 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		897934EF1E4CDC8800546131 /* MCLabel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MCLabel.m; sourceTree = "<group>"; };
+		89CC4A3A1E4CEEFD00323361 /* XCUITestExtensionsTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUITestExtensionsTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		89CC4A3B1E4CEEFE00323361 /* MCLabelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MCLabelTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		897934C31E4CD03300546131 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				897934ED1E4CD51E00546131 /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		897934D71E4CD1DA00546131 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				897934DF1E4CD1DA00546131 /* XCUITestExtensions.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		897934BD1E4CD03300546131 = {
+			isa = PBXGroup;
+			children = (
+				897934C91E4CD03300546131 /* XCUITestExtensions */,
+				897934DB1E4CD1DA00546131 /* XCUITestExtensionsTests */,
+				897934C81E4CD03300546131 /* Products */,
+				897934E51E4CD2A800546131 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		897934C81E4CD03300546131 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				897934C71E4CD03300546131 /* XCUITestExtensions.framework */,
+				897934DA1E4CD1DA00546131 /* XCUITestExtensionsTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		897934C91E4CD03300546131 /* XCUITestExtensions */ = {
+			isa = PBXGroup;
+			children = (
+				897934CA1E4CD03300546131 /* XCUITestExtensions.h */,
+				897934CB1E4CD03300546131 /* Info.plist */,
+				897934D21E4CD0A400546131 /* MCLabel.h */,
+				897934EF1E4CDC8800546131 /* MCLabel.m */,
+			);
+			path = XCUITestExtensions;
+			sourceTree = "<group>";
+		};
+		897934DB1E4CD1DA00546131 /* XCUITestExtensionsTests */ = {
+			isa = PBXGroup;
+			children = (
+				897934DC1E4CD1DA00546131 /* MCLabelTests.m */,
+				897934DE1E4CD1DA00546131 /* Info.plist */,
+				89CC4A3B1E4CEEFE00323361 /* MCLabelTests.swift */,
+				89CC4A3A1E4CEEFD00323361 /* XCUITestExtensionsTests-Bridging-Header.h */,
+			);
+			path = XCUITestExtensionsTests;
+			sourceTree = "<group>";
+		};
+		897934E51E4CD2A800546131 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				897934E61E4CD2A800546131 /* XCTest.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		897934C41E4CD03300546131 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				897934CC1E4CD03300546131 /* XCUITestExtensions.h in Headers */,
+				897934D41E4CD0A400546131 /* MCLabel.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		897934C61E4CD03300546131 /* XCUITestExtensions */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 897934CF1E4CD03300546131 /* Build configuration list for PBXNativeTarget "XCUITestExtensions" */;
+			buildPhases = (
+				897934C21E4CD03300546131 /* Sources */,
+				897934C31E4CD03300546131 /* Frameworks */,
+				897934C41E4CD03300546131 /* Headers */,
+				897934C51E4CD03300546131 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = XCUITestExtensions;
+			productName = XCUITestExtensions;
+			productReference = 897934C71E4CD03300546131 /* XCUITestExtensions.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		897934D91E4CD1DA00546131 /* XCUITestExtensionsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 897934E21E4CD1DA00546131 /* Build configuration list for PBXNativeTarget "XCUITestExtensionsTests" */;
+			buildPhases = (
+				897934D61E4CD1DA00546131 /* Sources */,
+				897934D71E4CD1DA00546131 /* Frameworks */,
+				897934D81E4CD1DA00546131 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				897934E11E4CD1DA00546131 /* PBXTargetDependency */,
+			);
+			name = XCUITestExtensionsTests;
+			productName = XCUITestExtensionsTests;
+			productReference = 897934DA1E4CD1DA00546131 /* XCUITestExtensionsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		897934BE1E4CD03300546131 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0820;
+				ORGANIZATIONNAME = microsoft;
+				TargetAttributes = {
+					897934C61E4CD03300546131 = {
+						CreatedOnToolsVersion = 8.2.1;
+						DevelopmentTeam = FYD86LA7RE;
+						ProvisioningStyle = Automatic;
+					};
+					897934D91E4CD1DA00546131 = {
+						CreatedOnToolsVersion = 8.2.1;
+						DevelopmentTeam = FYD86LA7RE;
+						LastSwiftMigration = 0820;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 897934C11E4CD03300546131 /* Build configuration list for PBXProject "XCUITestExtensions" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 897934BD1E4CD03300546131;
+			productRefGroup = 897934C81E4CD03300546131 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				897934C61E4CD03300546131 /* XCUITestExtensions */,
+				897934D91E4CD1DA00546131 /* XCUITestExtensionsTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		897934C51E4CD03300546131 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		897934D81E4CD1DA00546131 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		897934C21E4CD03300546131 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				897934F01E4CDC8800546131 /* MCLabel.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		897934D61E4CD1DA00546131 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				89CC4A3C1E4CEEFE00323361 /* MCLabelTests.swift in Sources */,
+				897934E91E4CD35900546131 /* MCLabelTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		897934E11E4CD1DA00546131 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 897934C61E4CD03300546131 /* XCUITestExtensions */;
+			targetProxy = 897934E01E4CD1DA00546131 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		897934CD1E4CD03300546131 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		897934CE1E4CD03300546131 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		897934D01E4CD03300546131 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = FYD86LA7RE;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				INFOPLIST_FILE = XCUITestExtensions/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.XCUITestExtensions;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		897934D11E4CD03300546131 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = FYD86LA7RE;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				INFOPLIST_FILE = XCUITestExtensions/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.XCUITestExtensions;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		897934E31E4CD1DA00546131 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEVELOPMENT_TEAM = FYD86LA7RE;
+				INFOPLIST_FILE = XCUITestExtensionsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.XCUITestExtensionsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "XCUITestExtensionsTests/XCUITestExtensionsTests-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		897934E41E4CD1DA00546131 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEVELOPMENT_TEAM = FYD86LA7RE;
+				INFOPLIST_FILE = XCUITestExtensionsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.XCUITestExtensionsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "XCUITestExtensionsTests/XCUITestExtensionsTests-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		897934C11E4CD03300546131 /* Build configuration list for PBXProject "XCUITestExtensions" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				897934CD1E4CD03300546131 /* Debug */,
+				897934CE1E4CD03300546131 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		897934CF1E4CD03300546131 /* Build configuration list for PBXNativeTarget "XCUITestExtensions" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				897934D01E4CD03300546131 /* Debug */,
+				897934D11E4CD03300546131 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		897934E21E4CD1DA00546131 /* Build configuration list for PBXNativeTarget "XCUITestExtensionsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				897934E31E4CD1DA00546131 /* Debug */,
+				897934E41E4CD1DA00546131 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 897934BE1E4CD03300546131 /* Project object */;
+}

--- a/XCUITestExtensions.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/XCUITestExtensions.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:/Users/chrisf/test-cloud-xcuitest-extensions/XCUITestExtensions.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/XCUITestExtensions/Info.plist
+++ b/XCUITestExtensions/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/XCUITestExtensions/MCLabel.h
+++ b/XCUITestExtensions/MCLabel.h
@@ -1,0 +1,22 @@
+
+#import <Foundation/Foundation.h>
+
+/*
+    Use 
+        [MCLabel label:fmt, ...]
+    to mark a particular 'test step' in your test. This will also trigger a screenshot. 
+ 
+    You can use `label(...)` as a convenience macro instead.
+ */
+
+@interface MCLabel : NSObject
++ (void)label:(NSString *)fmt, ...;
+
+
+/*
+    For swift compatibility
+ */
++ (void)labelStep:(NSString *)msg;
++ (void)labelStep:(NSString *)fmt args:(va_list)args;
+#define label(...) [MCLabel label: __VA_ARGS__]
+@end

--- a/XCUITestExtensions/MCLabel.m
+++ b/XCUITestExtensions/MCLabel.m
@@ -1,0 +1,41 @@
+
+#import <XCTest/XCTest.h>
+#import "MCLabel.h"
+
+/*
+ This label prefix signifies to the event processor that this particular log
+ statement is intended to be treated as a label.
+ */
+const NSString *LABEL_PREFIX = @"CBX|";
+
+/*
+ Hijack XCUITest's _XCINFLog() function to transfer our label over the wire.
+ */
+void _XCINFLog(NSString *msg);
+
+@implementation MCLabel
+
++ (void)label:(NSString *)fmt, ... {
+    va_list args;
+    va_start(args, fmt);
+    [self labelStep:fmt args:args];
+    va_end(args);
+}
+
++ (void)labelStep:(NSString *)msg {
+    [self _label:msg];
+}
+
++ (void)labelStep:(NSString *)fmt args:(va_list)args {
+    NSString *lbl = [[NSString alloc] initWithFormat:fmt arguments:args];
+    [self _label:lbl];
+}
+
+/*
+    We add in the prefix and pass it along to XCTest
+ */
++ (void)_label:(NSString *)message {
+    _XCINFLog([NSString stringWithFormat:@"%@ %@", LABEL_PREFIX, message]);
+}
+
+@end

--- a/XCUITestExtensions/XCUITestExtensions.h
+++ b/XCUITestExtensions/XCUITestExtensions.h
@@ -1,0 +1,12 @@
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for XCUITestExtensions.
+FOUNDATION_EXPORT double XCUITestExtensionsVersionNumber;
+
+//! Project version string for XCUITestExtensions.
+FOUNDATION_EXPORT const unsigned char XCUITestExtensionsVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like
+
+#import <XCUITestExtensions/MCLabel.h>

--- a/XCUITestExtensionsTests/Info.plist
+++ b/XCUITestExtensionsTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/XCUITestExtensionsTests/MCLabelTests.m
+++ b/XCUITestExtensionsTests/MCLabelTests.m
@@ -1,0 +1,22 @@
+
+#import <XCTest/XCTest.h>
+#import "XCUITestExtensions.h"
+
+@interface MCLabelTests : XCTestCase
+
+@end
+
+@implementation MCLabelTests
+
+/*
+    Should compile and run without throwing
+ */
+- (void)testLabel {
+    [MCLabel label:@"Test with no args"];
+    label(@"Test with no args");
+    
+    [MCLabel label:@"Test with %@", @"args"];
+    label(@"Test with %@", @"args");
+}
+
+@end

--- a/XCUITestExtensionsTests/MCLabelTests.swift
+++ b/XCUITestExtensionsTests/MCLabelTests.swift
@@ -1,0 +1,10 @@
+
+import XCTest
+import XCUITestExtensions
+
+class MCLabelTests: XCTestCase {
+    func testLabel() {
+        MCLabel.labelStep("Test label")
+        MCLabel.labelStep("Test label with %@", args: getVaList(["args"]))
+    }
+}

--- a/XCUITestExtensionsTests/XCUITestExtensionsTests-Bridging-Header.h
+++ b/XCUITestExtensionsTests/XCUITestExtensionsTests-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "XCUITestExtensions.h"


### PR DESCRIPTION
# Motivation

Provides the initial implementation for 
```objective-c
+[MCLabel label:]
```

and, in Swift,
```swift
MCLabel.labelStep()
```

## Usage
Objective-C:
```objective-c
#import <XCUITestExtensions/XCUITestExtensions.h>

- (void)myTest {
    //...
  
    [MCLabel label:fmt, args ... ];
    // or
    label(fmt, ...);

    //...
}
```

Swift:
```swift
import XCUITestExtensions


class MyTestCase: XCTestCase {
    func myTestCase() {
        //...

        MCLabel.labelStep(message)
        MCLabel.labelStep(fmt, args: getVaList([ args, ... ]))

        //...
    }
}
```


This will trigger a screenshot in TestCloud/MCTest and mark the current test step with the provided label. 

## Notes

Swift can not call `label()` because `label:` is is an Objective-C variadic method, which can not be exported to Swift. Either `label:` or `labelStep:` may be called from Objective-C but only `labelStep()` may be called from Swift. 

There is also a convenience macro for Objective-C, `label()` which accepts the same arguments. 