### PR TITLE
Podspec: disable bitcode; XCTest.framework not compiled with bitcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,7 @@ _Note: If you are having trouble targeting the xtc command, try executing with t
 
 ### Xcode 8.3 and Swift
 
-If you are building Swift XCUITests using Xcode 8.3, you may encounter a build error related to bitcode.
-As a workaround, you can disable bitcode in your App target and your XCUITest target. To do this, 
-go to Build Settings, search for `ENABLE_BITCODE` and set the value to `No` for both targets. 
+If you are building Swift XCUITests using Xcode >= 8.3, you may encounter a build error related to bitcode.  As a workaround, you can disable bitcode in your XCUITest target. To do this,
+go to Build Settings, search for `ENABLE_BITCODE` and set the value to `NO` for the test target.  You should not need to change the setting for the App target.
 
 <img width="1076" alt="screen shot 2017-04-06 at 12 43 24 pm" src="https://cloud.githubusercontent.com/assets/3009852/24772614/de004eea-1ac6-11e7-975a-bcdfae01d068.png">

--- a/VSMobileCenterExtensions.podspec
+++ b/VSMobileCenterExtensions.podspec
@@ -13,4 +13,5 @@ Pod::Spec.new do |s|
   s.ios.framework    = 'XCTest'
   s.ios.deployment_target = '9.0'
   s.requires_arc = true
+  s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
 end


### PR DESCRIPTION
### Motivation

This is in the context of trying to make the CocoaPod configuration work with Swift

* XCUITestExtension Library w/ Swift Project, Xcode 8.3 [3059](https://msmobilecenter.visualstudio.com/Test/_workitems/edit/3059)

ENABLE_BITCODE=YES is the default for all Pods. 

XCTest.framework is not compiled with bitcode.

The Pods.xcodeproj has ENABLE_BITCODE=YES for the VSMobileCenterExtensions.framework target.

This change disables bitcode by default.

I updated the README Swift + Xcode 8.3 + Bitcode section - in my tests I found the AUT could have ENABLE_BITCODE=YES.





