### PR TITLE
MCLaunch: swizzle XCUIApplication#launch to turn off automation sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,24 +27,6 @@ your test methods.
 * Sierra or High Sierra
 * iOS >= 9.0
 
-When using Xcode 9.0, you must launch your application using our
-`MCLaunch` API.
-
-```
-### Objective-C
-
-XCUIApplication *app = mc_launch
-XCUIApplication *app = mc_launch_app([[XCUIApplication alloc] init]);
-
-XCUIApplication *app = [MCLaunch launch];
-XCUIApplication *app = [MCLaunch launchApplication:[[XCUIApplication alloc] init]];
-
-### Swift
-
-let app = MCLaunch.launch();
-let app = MCLaunch.launch(XCUIApplication())
-```
-
 ### Installation
 
 The extension can be added to your Xcode project using Cocoapods, Carthage,

--- a/TestApp/Tests/UI/MCLaunchTest.m
+++ b/TestApp/Tests/UI/MCLaunchTest.m
@@ -72,4 +72,17 @@
     [application terminate];
 }
 
+- (void)testLaunchMethodIsSwizzled {
+    XCUIApplication *application = [[XCUIApplication alloc] init];
+    XCTAssertNotNil(application);
+
+    [application launch];
+
+    XCUIApplicationState state = [MCLaunch stateForApplication:application];
+    XCTAssertFalse(state == XCUIApplicationStateUnknown);
+
+    label(@"XCUIApplication#launch was swizzled");
+    [application terminate];
+}
+
 @end


### PR DESCRIPTION
### Motivation

Turn off automation sessions by swizzling XCUIApplication#launch [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/21264)

We would like to avoid users having to use our `MCLaunch` methods.

The `MCLaunch` methods will still work, but are no longer necessary.

### Test

* https://testcloud.xamarin.com/test/flowers_74a9dfad-aba2-44a4-afcc-3dd26841dd58

In particular this step:

* https://testcloud.xamarin.com/test/flowers_74a9dfad-aba2-44a4-afcc-3dd26841dd58/?step=3_0_0

```
- (void)testLaunchMethodIsSwizzled {
    XCUIApplication *application = [[XCUIApplication alloc] init];
    XCTAssertNotNil(application);

    [application launch];

    XCUIApplicationState state = [MCLaunch stateForApplication:application];
    XCTAssertFalse(state == XCUIApplicationStateUnknown);

    label(@"XCUIApplication#launch was swizzled");
    [application terminate];
}
```

### TODO

I think I need to update the .podspec and instructions for linking to include `-ObjC` linker flag.

- [ ] Create stand alone project that links with CocoaPods
- [ ] Create stand alone project that links with Carthage
- [ ] Create stand alone project that links with VSMobileCenterExtension.framework